### PR TITLE
Use kernel_id from provider's manager

### DIFF
--- a/notebook/services/kernels/kernelmanager.py
+++ b/notebook/services/kernels/kernelmanager.py
@@ -322,13 +322,16 @@ class MappingKernelManager(LoggingConfigurable):
         """
         if path is not None:
             kwargs['cwd'] = self.cwd_for_path(path)
-        kernel_id = str(uuid.uuid4())
+
         if kernel_name is None:
             kernel_name = 'pyimport/kernel'
         elif '/' not in kernel_name:
             kernel_name = 'spec/' + kernel_name
 
         kernel = KernelInterface(kernel_name, self.kernel_finder)
+        kernel_id = kernel.manager.kernel_id
+        if kernel_id is None:  # if provider didn't set a kernel_id, let's associate one to this kernel
+            kernel_id = str(uuid.uuid4())
         self._kernels[kernel_id] = kernel
 
         self.start_watching_activity(kernel_id)

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ for more information.
         'traitlets>=4.2.1',
         'jupyter_core>=4.4.0',
         'jupyter_client>=5.2.0',
-        'jupyter_kernel_mgmt>=0.3',
+        'jupyter_kernel_mgmt>=0.4',
         'jupyter_protocol',
         'nbformat',
         'nbconvert',


### PR DESCRIPTION
Update to use the kernel-id generated by the provider.  If not set we'll go ahead and assign an id anyway.  If we decide to raise an issue (or log a warning), that's fine as well.  This approach seemed the least intrusive.